### PR TITLE
Default slave group for the DB write

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -10,6 +10,7 @@ module Octopus
              :current_shard, :current_shard=,
              :current_group, :current_group=,
              :current_slave_group, :current_slave_group=,
+             :default_slave_group, :default_slave_group=,
              :current_load_balance_options, :current_load_balance_options=,
              :block, :block=, :fully_replicated?, :has_group?,
              :shard_names, :shards_for_group, :shards, :sharded, :slaves_list,

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -59,6 +59,8 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
       end
 
+      self.current_slave_group = nil if shard_symbol == :master
+      self.default_slave_group = nil if shard_symbol == :master
       Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end
 

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -47,7 +47,7 @@ module Octopus
           fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
         end
 
-        if slave_group_symbol.present?
+        if slave_group_symbol.present?git
           if (shards_slave_groups.try(:[], shard_symbol).present? && shards_slave_groups[shard_symbol][slave_group_symbol].nil?) ||
               (shards_slave_groups.try(:[], shard_symbol).nil? && @slave_groups[slave_group_symbol].nil?)
             fail "Nonexistent Slave Group Name: #{slave_group_symbol} in shards config: #{shards_config.inspect}"
@@ -59,7 +59,7 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
       end
 
-      self.current_slave_group = nil if shard_symbol == :master
+      # self.current_slave_group = nil if shard_symbol == :master
       self.default_slave_group = nil if shard_symbol == :master
       Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -47,7 +47,7 @@ module Octopus
           fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
         end
 
-        if slave_group_symbol.present?git
+        if slave_group_symbol.present?
           if (shards_slave_groups.try(:[], shard_symbol).present? && shards_slave_groups[shard_symbol][slave_group_symbol].nil?) ||
               (shards_slave_groups.try(:[], shard_symbol).nil? && @slave_groups[slave_group_symbol].nil?)
             fail "Nonexistent Slave Group Name: #{slave_group_symbol} in shards config: #{shards_config.inspect}"

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -59,7 +59,7 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
       end
 
-      # self.current_slave_group = nil if shard_symbol == :master
+      self.current_slave_group = nil if shard_symbol == :master
       self.default_slave_group = nil if shard_symbol == :master
       Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -10,7 +10,7 @@ module Octopus
 
     attr_accessor :config, :sharded, :shards, :shards_slave_groups, :slave_groups,
                   :adapters, :replicated, :slaves_load_balancer, :slaves_list, :shards_slave_groups,
-                  :slave_groups, :groups, :entire_sharded, :shards_config
+                  :slave_groups, :groups, :entire_sharded, :shards_config, :default_slave_group
 
     def initialize(config)
       initialize_shards(config)
@@ -76,7 +76,7 @@ module Octopus
     end
 
     def current_slave_group
-      Thread.current[CURRENT_SLAVE_GROUP_KEY]
+      Thread.current[CURRENT_SLAVE_GROUP_KEY] || default_slave_group
     end
 
     def current_slave_group=(slave_group_symbol)

--- a/lib/octopus/version.rb
+++ b/lib/octopus/version.rb
@@ -1,3 +1,3 @@
 module Octopus
-  VERSION = '0.10.2'
+  VERSION = '0.10.3'
 end


### PR DESCRIPTION
# Issue
[Jira ticket](https://change.atlassian.net/browse/CHANGE-47698)
# Overview
On production currently all `SELECT` queries are still go to `master` instead of slave. This started happening when we added a new `vanity_url` postgres connection to the mix. Octopus(not Octopus squad) when initialized with the `current_slave_group=:monorail` doesn't seem to get precedence in this case, which makes all the `SELECT` queries go to `master`
# Approach
Adding a `default_slave_group` to force `SELECT` queries to go to `slave= :monorail`. During testing we found that `petition_service` `dia_custom_target` and `petition_target` fails because we are using the [`.lock`](https://github.com/change/petition_service/blob/master/app/models/dia_custom_target.rb#L28) on the matching. In that case we can't use the slave, since it is a `Select... for Update` query and it should go to master. The resolution for that is to use `.using(:master)` explicitly. 
## Related PR
https://github.com/change/petition_service/pull/766