### PR TITLE
Allow override of default_slave_group

### DIFF
--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -59,6 +59,8 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
       end
 
+      self.current_slave_group = nil if shard_symbol == :master
+      self.default_slave_group = nil if shard_symbol == :master
       Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end
 

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -47,7 +47,7 @@ module Octopus
           fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
         end
 
-        if slave_group_symbol.present?
+        if slave_group_symbol.present?git
           if (shards_slave_groups.try(:[], shard_symbol).present? && shards_slave_groups[shard_symbol][slave_group_symbol].nil?) ||
               (shards_slave_groups.try(:[], shard_symbol).nil? && @slave_groups[slave_group_symbol].nil?)
             fail "Nonexistent Slave Group Name: #{slave_group_symbol} in shards config: #{shards_config.inspect}"
@@ -59,7 +59,7 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
       end
 
-      self.current_slave_group = nil if shard_symbol == :master
+      # self.current_slave_group = nil if shard_symbol == :master
       self.default_slave_group = nil if shard_symbol == :master
       Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -47,7 +47,7 @@ module Octopus
           fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
         end
 
-        if slave_group_symbol.present?git
+        if slave_group_symbol.present?
           if (shards_slave_groups.try(:[], shard_symbol).present? && shards_slave_groups[shard_symbol][slave_group_symbol].nil?) ||
               (shards_slave_groups.try(:[], shard_symbol).nil? && @slave_groups[slave_group_symbol].nil?)
             fail "Nonexistent Slave Group Name: #{slave_group_symbol} in shards config: #{shards_config.inspect}"

--- a/lib/octopus/proxy_config.rb
+++ b/lib/octopus/proxy_config.rb
@@ -59,7 +59,7 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if shards[shard_symbol].nil?
       end
 
-      # self.current_slave_group = nil if shard_symbol == :master
+      self.current_slave_group = nil if shard_symbol == :master
       self.default_slave_group = nil if shard_symbol == :master
       Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end


### PR DESCRIPTION
Normally if you specify to use the the master shard then the current slave group is set to nil, but as long as default_slave_group was present it would continue to be used.

This allows us to force the master shard by using `using(:master)`

@rtrehan @GreenMonkeySaveEarth 