### PR TITLE
Use thread variable for forcing master reads

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -336,7 +336,6 @@ module Octopus
     # Temporarily switch `current_shard` and run the block
     def using_shard(shard, &_block)
       older_shard = current_shard
-      older_default_slave_group = default_slave_group
       older_slave_group = current_slave_group
       older_load_balance_options = current_load_balance_options
 
@@ -348,7 +347,6 @@ module Octopus
       ensure
         self.current_shard = older_shard
         self.current_slave_group = older_slave_group
-        self.default_slave_group = older_default_slave_group
         self.current_load_balance_options = older_load_balance_options
       end
     end


### PR DESCRIPTION
The previous approach of unsetting and setting `default_slave_group` was not thread safe. We need an instance variable in order for it to be preserved across threads (I can’t find any way to tie into puma’s thread forking to set a `current_slave_group` after a fork). However we can’t be making changes to this variable across multiple threads and expecting it to be safe.

This approach uses a thread variable to say that a :master query has been requested, and then to clear it when the `current_slave_group` is reset back to what it was.

@rc9 @ysgard 